### PR TITLE
Add Reserve Balance

### DIFF
--- a/pos/Qt GUI/reserve balance.md
+++ b/pos/Qt GUI/reserve balance.md
@@ -28,7 +28,7 @@ Check how reservebalance work.
 Set reserve balance with some of the three possible ways:
  1. Set in `qtum.conf` `reservebalance=<value>` before starting `qtum-qt` or
  2. Start  `qtum-qt -reservebalance=<value>` or
- 3. Call `reservebalance true <value>` from Console in Help-dialog after starting `qtum-qt`
+ 3. Call `reservebalance true <value>` from Console in Help-dialog after starting `qtum-qt`  
 Connect to the network and mine blocks. Wait until the consensus protocol is switched to PoS.
 
 ## Test Steps

--- a/pos/RPC reserve balance.md
+++ b/pos/RPC reserve balance.md
@@ -18,6 +18,6 @@ Connect to the network and have enough matured coins.
 
 ## Expected Results
 
-Steps 2, 3, 4 and 5 should result in Reserve balance set to 0.
-Step 6 should result in Reserve Balance set to `<value>`
+Steps 2, 3, 4 and 5 should result in Reserve balance set to 0.  
+Step 6 should result in Reserve Balance set to `<value>`  
 Step 7 should result in only showing Reserve Balance.


### PR DESCRIPTION
The reserve balance is the coins which are reserved and not used for staking. The parameter nReserveBalance define the reserve balance. It can be checked by searching in Blackcoin for reservebalance.
The following functionalities contain reserve balance and require update:
-reservebalance parameter that can be set when the application is initialized or in the configuration file
RPC call for the reserve balance
reduce the stake and the available coins for staking by the reserve balance
label for displaying the reserve balance into the optionsdialog.ui and update of the model (Qt Wallet)