### PR TITLE
Mutualized Proof Of Stake Block Reward

### DIFF
--- a/pos/MPoS reward checks.md
+++ b/pos/MPoS reward checks.md
@@ -10,24 +10,23 @@ Connect to the network and mine blocks. Wait until the consensus protocol is swi
 ## Test Steps
 
 1. Start `qtumd` and wait to mine at least 500 PoS blocks.
-2. After those 500 blocks when you mine block B1, check `qtum-cli getsubsidy <mined B1 height>`
-3. Check if subsidy earned is `1/10` (from the value returned in step 2  + fee).
+2. After those 500 blocks when you mine block B1, get the PoS transaction to check the reward info:  `getblock <B1 hash>`, `gettransaction <Second(PoS)tx ID>` from B1.
+3. Check if "amount" field is `1/10` (from the "fee" field).
 4. Wait for next 499 block to be mined.
-5. Check your balance `qtum-cli getbalance` and wait for the 500-th block to be mined.
-6. After 500-th block is mined check your balance again and do it after every block mined until 510.
-7. After 510-th block check the balance once more.
+5. After 500-th block is mined check reward info as explained in step 2 and do it after every block mined until 510.
+6. After 510-th block check reward info again.
 
 ## Expected Results
 
-In step 3 you should see that the miner don't get the full reward he get only `1/10` (from the mined block + fee).
+In step 3 you should see that the miner don't get the full reward he get only `1/10` (from the mined block subsidy + fee).
 
- Step 6 should result in getting `1/10` from the subsidy from block B1 in every block from 500 to 509.
+Step 5 should result in getting `1/10` from the reward(subsidy + fee) from every block from 500 to 509 ("amount" field = `1/10` from "fee" field)
 
-Step 7 should result in not getting more rewards, because the subsidy for block B1 is completed.
+Step 6 should result in not getting more rewards, because the reward for block B1 is completed (you got `1/10` rewards from 10 blocks).
 
 ## Note
 
-This scenario is true in case, the next 9 blocks after B1 are mined by other miners, not by you. If you mine some of the next 9 blocks ex. B2 on height `B1 height + 3`, in blocks on height from `B1 height + 503` to `B1 height + 509` which is equal to `B2 height + 500` to `B2 height + 506` you will have reward `1/10` from B1 + `1/10` from B2. In the next blocks until `B2 height + 509` you will get reward `1/10` from B2.  
+This scenario is true in case, the next 9 blocks after B1 are mined by other miners, not by you. If you mine some of the next 9 blocks ex. B2 on height `B1 height + 3`. In blocks on height from `B1 height + 503` to `B1 height + 509` which is equal to `B2 height + 500` to `B2 height + 506` you will have reward `2/10` from that block's rewards(subsidy + fee). In the next blocks until `B2 height + 509` you will get `1/10` from the reward again.  
 
 
 
@@ -69,4 +68,4 @@ Connect to the network and mine blocks. Wait until the consensus protocol is swi
 
 ## Expected results
 
-Step 3 should show that the block reward for the first 500 PoS blocks is complete, it's not splitted between mutual miners.
+Step 3 should show that the block reward for the first 500 PoS blocks is complete, it's not splited between mutual miners.


### PR DESCRIPTION
1. Prevent malicious miners from attacking the network for free by constructing expensive to validate blocks, and then receiving all of the gas fees back to themselves through the mining process
2. Help to make it more difficult and expensive for an attacker to DoS the network.